### PR TITLE
feat: Mattermost Boards support

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,11 +87,74 @@ Replace `/absolute/path/to/focalboard-mcp-server` with the actual path to this p
 
 ## Configuration
 
-### Required Environment Variables
+The server supports two setups: **standalone Focalboard** (username/password login) and **Mattermost Boards** (the Focalboard plugin behind Mattermost, using a Personal Access Token).
 
-- `FOCALBOARD_HOST`: The URL of your Focalboard instance (e.g., `https://focalboard.example.com`)
-- `FOCALBOARD_USERNAME`: Your Focalboard username or email
-- `FOCALBOARD_PASSWORD`: Your Focalboard password
+### Standalone Focalboard
+
+- `FOCALBOARD_HOST`: Root URL of the Focalboard server (e.g., `https://focalboard.example.com`)
+- `FOCALBOARD_USERNAME`: Username or email for `POST /api/v2/login`
+- `FOCALBOARD_PASSWORD`: Password for that account
+
+Do **not** set `FOCALBOARD_TOKEN` / `MATTERMOST_ACCESS_TOKEN` when using this mode.
+
+### Mattermost Boards (plugin)
+
+The API is still Focalboard v2, but it is mounted under the Mattermost server. Set the host to the **plugin base** (no trailing slash), not the Mattermost root alone:
+
+```text
+https://<mattermost-host>/plugins/focalboard
+```
+
+The client appends `/api/v2/...` to that base. If you use only `https://<mattermost-host>`, requests can hit Mattermost’s core API instead of Boards.
+
+Authentication uses a **Mattermost Personal Access Token** (Profile → Security → Personal Access Tokens). On many Mattermost deployments, Boards API requests with `Authorization: Bearer <PAT>` also require **`X-Requested-With: XMLHttpRequest`** so CSRF checks treat the call like an XHR; this server sends that header on **every** API request.
+
+**Environment variables (token mode):**
+
+- `FOCALBOARD_HOST`: `https://<mattermost-host>/plugins/focalboard`
+- `FOCALBOARD_TOKEN` **or** `MATTERMOST_ACCESS_TOKEN`: the PAT value (`mm_pat_...`)
+
+Username and password are optional and ignored when a token is set.
+
+**Team ID:** For `list_boards` / `search_boards`, use the **real team id** from the Boards URL (`/boards/team/<teamId>/...`), not `"0"`.
+
+**Example `curl` (operators):**
+
+```bash
+export TOKEN='mm_pat_...'
+export HOST='https://your-mattermost.example.com/plugins/focalboard'
+
+curl -sS -H "Authorization: Bearer ${TOKEN}" \
+  -H 'Accept: application/json' \
+  -H 'X-Requested-With: XMLHttpRequest' \
+  "${HOST}/api/v2/users/me"
+```
+
+**Example MCP config (Cursor / Claude Desktop):**
+
+```json
+{
+  "mcpServers": {
+    "focalboard": {
+      "command": "node",
+      "args": ["/absolute/path/to/focalboard-mcp-server/build/index.js"],
+      "env": {
+        "FOCALBOARD_HOST": "https://your-mattermost.example.com/plugins/focalboard",
+        "FOCALBOARD_TOKEN": "mm_pat_..."
+      }
+    }
+  }
+}
+```
+
+**Security:** Treat the PAT like a password. Prefer OS-level secret storage or your client’s secret mechanism for MCP `env`; this server does not log the token.
+
+### Required environment variables (summary)
+
+| Mode | Variables |
+|------|-----------|
+| Standalone | `FOCALBOARD_HOST`, `FOCALBOARD_USERNAME`, `FOCALBOARD_PASSWORD` |
+| Mattermost Boards | `FOCALBOARD_HOST` (plugin base URL), `FOCALBOARD_TOKEN` or `MATTERMOST_ACCESS_TOKEN` |
 
 ## Available Tools
 
@@ -304,11 +367,9 @@ Descriptions support full markdown formatting:
 
 ### Authentication
 
-The server automatically handles authentication:
-1. When first called, it logs in with your username/password
-2. Receives a session token from Focalboard
-3. Uses the token for all subsequent API requests
-4. Automatically re-authenticates if the token expires
+**Standalone:** On first API use, the client calls `POST /api/v2/login` with username/password, stores the session token, sends `Authorization: Bearer` and `X-Requested-With: XMLHttpRequest` on subsequent requests, and retries login once after a `401`.
+
+**Mattermost Boards:** If `FOCALBOARD_TOKEN` or `MATTERMOST_ACCESS_TOKEN` is set, login is skipped; the PAT is sent as `Authorization: Bearer` on every request, with the same CSRF-related header. A `401` is not retried with password login.
 
 ### Column Name Resolution
 

--- a/README.md
+++ b/README.md
@@ -194,6 +194,20 @@ Search for boards by name or keyword.
 Search for boards with "project" in the name
 ```
 
+#### `list_board_users`
+List board members with **resolved usernames** (via `GET /boards/{boardId}/members` and `POST /users`). Use this when you need an Assignee but only know a Mattermost username.
+
+**Parameters:**
+- `boardId` (required): The board ID
+- `search` (optional): Case-insensitive substring filter (username, email, names, user id)
+
+**Assignee / person fields (`create_card` / `update_card`):**
+- **Mattermost user ID** (26 lowercase alphanumeric characters), e.g. from `list_board_users`
+- **`@username`** for a user who is a **member of that board** (exact username match, case-insensitive)
+- **Several assignees:** comma-separated ids/usernames, or a JSON array string: `["id1","id2"]`
+
+The API stores person / multiPerson values as **arrays of user IDs**; the server now sends that shape so assignees show correctly in Boards.
+
 ### Card/Task Operations
 
 #### `create_card`
@@ -202,7 +216,7 @@ Create a new card (task) in a board with optional description.
 **Parameters:**
 - `boardId` (required): The board ID
 - `title` (required): Card title
-- `properties` (optional): Property values as key-value pairs using property names
+- `properties` (optional): Property values as key-value pairs using property names (see **Assignee** above)
 - `description` (optional): Card description in markdown format
 
 **Example:**
@@ -241,7 +255,7 @@ Update a card's properties, title, and/or description.
 - `cardId` (required): The card ID
 - `boardId` (required): The board ID
 - `title` (optional): New title
-- `properties` (optional): Property values to update using property names
+- `properties` (optional): Property values to update using property names (see **list_board_users** / Assignee above)
 - `description` (optional): Update or set the card description in markdown format
 
 **Example:**

--- a/src/focalboard-client.ts
+++ b/src/focalboard-client.ts
@@ -8,7 +8,8 @@ import {
   CardPatch,
   PropertyTemplate,
   ErrorResponse,
-  Block
+  Block,
+  Team
 } from './types.js';
 
 export class FocalboardClient {
@@ -166,6 +167,13 @@ export class FocalboardClient {
   // ====================
 
   /**
+   * List teams the current user can access (Mattermost: all member teams; standalone: root team(s)).
+   */
+  async listTeams(): Promise<Team[]> {
+    return this.makeRequest<Team[]>('/teams');
+  }
+
+  /**
    * List all boards for a team
    */
   async listBoards(teamId: string = '0'): Promise<Board[]> {
@@ -271,9 +279,41 @@ export class FocalboardClient {
   }
 
   /**
+   * Reads card custom properties from API shape (`fields.properties` or top-level `properties`).
+   * Focalboard PATCH replaces the whole `properties` map when only a subset is sent, so callers merge here.
+   */
+  private getCardPropertiesSnapshot(card: Card): Record<string, string | string[]> {
+    const fromFields = card.fields?.properties;
+    if (fromFields && typeof fromFields === 'object' && !Array.isArray(fromFields)) {
+      return { ...(fromFields as Record<string, string | string[]>) };
+    }
+    const top = (card as unknown as { properties?: Record<string, string | string[]> }).properties;
+    if (top && typeof top === 'object' && !Array.isArray(top)) {
+      return { ...top };
+    }
+    return {};
+  }
+
+  /**
    * Update a card
    */
   async updateCard(boardId: string, cardId: string, patch: CardPatch): Promise<Card> {
+    const incoming = patch.updatedFields?.properties;
+    if (incoming && typeof incoming === 'object' && !Array.isArray(incoming)) {
+      const current = await this.getCard(cardId);
+      const merged = {
+        ...this.getCardPropertiesSnapshot(current),
+        ...(incoming as Record<string, string | string[]>),
+      };
+      patch = {
+        ...patch,
+        updatedFields: {
+          ...patch.updatedFields,
+          properties: merged,
+        },
+      };
+    }
+
     await this.makeRequest<void>(
       `/boards/${boardId}/blocks/${cardId}`,
       'PATCH',

--- a/src/focalboard-client.ts
+++ b/src/focalboard-client.ts
@@ -15,20 +15,34 @@ export class FocalboardClient {
   private host: string;
   private username: string;
   private password: string;
+  /** Non-null when using Mattermost PAT (or other pre-provisioned Bearer token). */
+  private readonly pat: string | null;
   private sessionToken: string | null = null;
   private readonly apiBasePath = '/api/v2';
 
   constructor(config: FocalboardConfig) {
     // Ensure host doesn't have trailing slash
     this.host = config.host.replace(/\/$/, '');
-    this.username = config.username;
-    this.password = config.password;
+    const trimmedPat = config.accessToken?.trim();
+    this.pat = trimmedPat && trimmedPat.length > 0 ? trimmedPat : null;
+    this.username = config.username ?? '';
+    this.password = config.password ?? '';
+    if (this.pat) {
+      this.sessionToken = this.pat;
+    }
+  }
+
+  private isPatMode(): boolean {
+    return this.pat !== null;
   }
 
   /**
    * Login and get session token
    */
   private async login(): Promise<void> {
+    if (this.isPatMode()) {
+      throw new Error('login() must not be called in access-token (Mattermost PAT) mode');
+    }
     const loginPayload: LoginRequest = {
       type: 'normal',
       username: this.username,
@@ -59,6 +73,10 @@ export class FocalboardClient {
    * Ensure we have a valid session token
    */
   private async ensureAuthenticated(): Promise<void> {
+    if (this.isPatMode()) {
+      this.sessionToken = this.pat;
+      return;
+    }
     if (!this.sessionToken) {
       await this.login();
     }
@@ -99,12 +117,14 @@ export class FocalboardClient {
       body: body ? JSON.stringify(body) : undefined
     });
 
-    // Handle 401 - try to re-authenticate once
+    // Handle 401 — password mode may refresh session; PAT mode must not call login()
     if (response.status === 401) {
+      if (this.isPatMode()) {
+        return this.handleResponse<T>(response);
+      }
       this.sessionToken = null;
       await this.login();
 
-      // Retry the request with new token
       headers['Authorization'] = `Bearer ${this.sessionToken}`;
       const retryResponse = await fetch(url, {
         method,

--- a/src/focalboard-client.ts
+++ b/src/focalboard-client.ts
@@ -4,12 +4,15 @@ import {
   LoginRequest,
   LoginResponse,
   Board,
+  BoardMember,
+  BoardUserRow,
   Card,
   CardPatch,
   PropertyTemplate,
   ErrorResponse,
   Block,
-  Team
+  Team,
+  User,
 } from './types.js';
 
 export class FocalboardClient {
@@ -185,6 +188,67 @@ export class FocalboardClient {
    */
   async getBoard(boardId: string): Promise<Board> {
     return this.makeRequest<Board>(`/boards/${boardId}`);
+  }
+
+  /**
+   * Board members (roles only). Use {@link listBoardUsers} for usernames.
+   */
+  async getBoardMembers(boardId: string): Promise<BoardMember[]> {
+    return this.makeRequest<BoardMember[]>(`/boards/${boardId}/members`);
+  }
+
+  /**
+   * Resolve user profiles for a list of Mattermost / Focalboard user IDs.
+   */
+  async getUsersByIds(userIds: string[]): Promise<User[]> {
+    if (userIds.length === 0) {
+      return [];
+    }
+    return this.makeRequest<User[]>('/users', 'POST', userIds);
+  }
+
+  /**
+   * Members of a board with usernames (and optional substring filter).
+   */
+  async listBoardUsers(boardId: string, query?: string): Promise<BoardUserRow[]> {
+    const members = await this.getBoardMembers(boardId);
+    const userIds = [
+      ...new Set(
+        members
+          .map((m) => (m as { userId?: string; user_id?: string }).userId ?? (m as { user_id?: string }).user_id)
+          .filter(Boolean) as string[]
+      ),
+    ];
+    let users: User[] = [];
+    if (userIds.length > 0) {
+      users = await this.getUsersByIds(userIds);
+    }
+    const byId = new Map(users.map((u) => [u.id, u]));
+    const needle = (query ?? '').trim().toLowerCase();
+    const rows: BoardUserRow[] = members.map((m) => {
+      const userId =
+        (m as { userId?: string; user_id?: string }).userId ?? (m as { user_id?: string }).user_id ?? '';
+      const u = userId ? byId.get(userId) : undefined;
+      return {
+        userId,
+        username: u?.username ?? '',
+        email: u?.email ?? '',
+        firstname: u?.firstname ?? '',
+        lastname: u?.lastname ?? '',
+        nickname: u?.nickname ?? '',
+        schemeAdmin: !!m.schemeAdmin,
+        schemeEditor: !!m.schemeEditor,
+        schemeCommenter: !!m.schemeCommenter,
+        schemeViewer: !!m.schemeViewer,
+      };
+    });
+    if (!needle) {
+      return rows;
+    }
+    return rows.filter((r) => {
+      const hay = [r.userId, r.username, r.email, r.firstname, r.lastname, r.nickname].join(' ').toLowerCase();
+      return hay.includes(needle);
+    });
   }
 
   /**
@@ -372,6 +436,75 @@ export class FocalboardClient {
   }
 
   /**
+   * Mattermost-style user IDs used by Boards are typically 26 lowercase alphanumerics.
+   */
+  private looksLikeMattermostUserId(token: string): boolean {
+    const t = token.trim();
+    return /^[a-z0-9]{26}$/.test(t);
+  }
+
+  /**
+   * Split person / multiPerson property value into raw tokens (IDs or @username / username).
+   */
+  private parsePersonPropertyTokens(value: string): string[] {
+    const trimmed = value.trim();
+    if (!trimmed) {
+      return [];
+    }
+    if (trimmed.startsWith('[')) {
+      try {
+        const parsed = JSON.parse(trimmed) as unknown;
+        if (Array.isArray(parsed)) {
+          return (parsed as unknown[]).map((x) => String(x).trim()).filter(Boolean);
+        }
+        return [String(parsed).trim()];
+      } catch {
+        throw new Error(
+          `Invalid JSON for person property: expected a JSON array of user IDs or usernames`
+        );
+      }
+    }
+    return trimmed.split(/[\s,]+/).map((s) => s.trim()).filter(Boolean);
+  }
+
+  private resolvePersonTokenToUserId(token: string, boardUsers: BoardUserRow[]): string {
+    const t = token.trim();
+    if (!t) {
+      throw new Error('Empty person / assignee token');
+    }
+    if (this.looksLikeMattermostUserId(t)) {
+      return t;
+    }
+    const uname = t.replace(/^@/, '').toLowerCase();
+    const matches = boardUsers.filter((row) => row.username.toLowerCase() === uname);
+    if (matches.length === 1) {
+      return matches[0].userId;
+    }
+    if (matches.length === 0) {
+      throw new Error(
+        `No board member with username "${uname}". Use list_board_users, or pass the Mattermost user ID (26 chars).`
+      );
+    }
+    throw new Error(`Ambiguous username "${uname}"`);
+  }
+
+  private resolvePersonPropertyValue(
+    value: string,
+    multi: boolean,
+    boardUsers: BoardUserRow[]
+  ): string[] {
+    const tokens = this.parsePersonPropertyTokens(value);
+    if (tokens.length === 0) {
+      throw new Error('Person property requires at least one user ID or @username');
+    }
+    if (!multi && tokens.length > 1) {
+      throw new Error('Person property accepts only one user (use multiPerson / Assignee for several users)');
+    }
+    const toResolve = multi ? tokens : tokens.slice(0, 1);
+    return toResolve.map((tok) => this.resolvePersonTokenToUserId(tok, boardUsers));
+  }
+
+  /**
    * Update card properties with friendly names
    * Accepts property names and values, resolves to IDs internally
    */
@@ -381,7 +514,13 @@ export class FocalboardClient {
     properties: Record<string, string>
   ): Promise<Card> {
     const board = await this.getBoard(boardId);
-    const propertyUpdates: Record<string, string> = {};
+    const propertyUpdates: Record<string, string | string[]> = {};
+
+    const needsBoardUsers = Object.keys(properties).some((propName) => {
+      const property = this.findPropertyByName(board, propName);
+      return property?.type === 'multiPerson' || property?.type === 'person';
+    });
+    const boardUsers = needsBoardUsers ? await this.listBoardUsers(boardId) : [];
 
     for (const [propName, value] of Object.entries(properties)) {
       const property = this.findPropertyByName(board, propName);
@@ -396,6 +535,11 @@ export class FocalboardClient {
           throw new Error(`Option '${value}' not found in property '${propName}'`);
         }
         propertyUpdates[property.id] = optionId;
+      } else if (property.type === 'multiPerson') {
+        propertyUpdates[property.id] = this.resolvePersonPropertyValue(value, true, boardUsers);
+      } else if (property.type === 'person') {
+        const ids = this.resolvePersonPropertyValue(value, false, boardUsers);
+        propertyUpdates[property.id] = ids[0];
       } else {
         // For other types, use the value directly
         propertyUpdates[property.id] = value;

--- a/src/index.ts
+++ b/src/index.ts
@@ -110,6 +110,26 @@ const tools: Tool[] = [
     }
   },
   {
+    name: 'list_board_users',
+    description:
+      'List users who are members of a board with usernames, emails, and role flags. Optional `search` filters by substring (username, email, name, user id). Use this to resolve Assignee / Reviewer without pasting Mattermost user IDs. Person fields also accept `@username` or a 26-char user id.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        boardId: {
+          type: 'string',
+          description: 'The board ID (same as get_board / create_card).',
+        },
+        search: {
+          type: 'string',
+          description:
+            'Optional case-insensitive substring; filters the list (username, email, first/last name, nickname, userId).',
+        },
+      },
+      required: ['boardId'],
+    },
+  },
+  {
     name: 'create_card',
     description: 'Create a new card (task) in a board. You can set the title, properties, description, and column placement.',
     inputSchema: {
@@ -125,7 +145,8 @@ const tools: Tool[] = [
         },
         properties: {
           type: 'object',
-          description: 'Property values for the card (e.g., {"Status": "To Do", "Priority": "High"}). Use property names, not IDs.',
+          description:
+            'Property values for the card (e.g., {"Status": "To Do", "Priority": "High", "Assignee": "@sara"}). Use property names, not IDs. For Assignee / person fields: Mattermost user id (26 chars), @username of a board member, comma-separated ids, or JSON array ["id1","id2"].',
           additionalProperties: {
             type: 'string'
           }
@@ -196,7 +217,8 @@ const tools: Tool[] = [
         },
         properties: {
           type: 'object',
-          description: 'Property values to update (e.g., {"Status": "In Progress", "Priority": "High"}). Use property names, not IDs.',
+          description:
+            'Property values to update (e.g., {"Status": "In Progress", "Assignee": "@mohammad"}). Use property names, not IDs. Assignee / person: user id, @username (board member), comma-separated, or JSON array.',
           additionalProperties: {
             type: 'string'
           }
@@ -357,6 +379,23 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
               text: JSON.stringify(boards, null, 2)
             }
           ]
+        };
+      }
+
+      case 'list_board_users': {
+        const boardId = args?.boardId as string;
+        const search = (args?.search as string) || undefined;
+        if (!boardId) {
+          throw new Error('boardId is required');
+        }
+        const rows = await focalboard.listBoardUsers(boardId, search);
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(rows, null, 2),
+            },
+          ],
         };
       }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -11,16 +11,32 @@ import { FocalboardClient } from './focalboard-client.js';
 import { FocalboardConfig } from './types.js';
 
 // Get configuration from environment variables
-const config: FocalboardConfig = {
-  host: process.env.FOCALBOARD_HOST || '',
-  username: process.env.FOCALBOARD_USERNAME || '',
-  password: process.env.FOCALBOARD_PASSWORD || ''
-};
+const host = (process.env.FOCALBOARD_HOST || '').trim();
+const accessToken = (
+  process.env.FOCALBOARD_TOKEN ||
+  process.env.MATTERMOST_ACCESS_TOKEN ||
+  ''
+).trim();
+const username = (process.env.FOCALBOARD_USERNAME || '').trim();
+const password = (process.env.FOCALBOARD_PASSWORD || '').trim();
+
+const config: FocalboardConfig = accessToken
+  ? { host, accessToken }
+  : { host, username, password };
 
 // Validate configuration
-if (!config.host || !config.username || !config.password) {
-  console.error('Error: Missing required environment variables');
-  console.error('Required: FOCALBOARD_HOST, FOCALBOARD_USERNAME, FOCALBOARD_PASSWORD');
+if (!host) {
+  console.error('Error: FOCALBOARD_HOST is required');
+  process.exit(1);
+}
+
+if (accessToken) {
+  // Mattermost Boards / PAT mode: host + token only
+} else if (!username || !password) {
+  console.error('Error: Missing credentials for standalone Focalboard');
+  console.error(
+    'Set FOCALBOARD_USERNAME and FOCALBOARD_PASSWORD, or use FOCALBOARD_TOKEN (or MATTERMOST_ACCESS_TOKEN) for Mattermost Boards.'
+  );
   process.exit(1);
 }
 
@@ -37,7 +53,8 @@ const tools: Tool[] = [
       properties: {
         teamId: {
           type: 'string',
-          description: 'The team ID to list boards for (default: "0" for default team)',
+          description:
+            'Team ID: use "0" for standalone Focalboard default team; for Mattermost Boards use the real team id from the board URL (/boards/team/<teamId>/...).',
           default: '0'
         }
       }
@@ -65,7 +82,8 @@ const tools: Tool[] = [
       properties: {
         teamId: {
           type: 'string',
-          description: 'The team ID to search within (default: "0" for default team)',
+          description:
+            'Team ID: "0" for standalone default team; Mattermost Boards needs the team id from the URL.',
           default: '0'
         },
         searchTerm: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -46,15 +46,30 @@ const focalboard = new FocalboardClient(config);
 // Define MCP tools
 const tools: Tool[] = [
   {
+    name: 'list_teams',
+    description:
+      'List teams the authenticated user can access. Each item includes `id` (use as `teamId` for list_boards / search_boards) and `title`. Optional `titleContains` filters by team name.',
+    inputSchema: {
+      type: 'object',
+      properties: {
+        titleContains: {
+          type: 'string',
+          description: 'Optional case-insensitive substring; only teams whose title matches are returned.',
+        },
+      },
+    },
+  },
+  {
     name: 'list_boards',
-    description: 'List all boards for a team. Returns an array of boards with their IDs, titles, and properties.',
+    description:
+      'List all boards for a team. Returns an array of boards with their IDs, titles, and properties. On Mattermost Boards, call list_teams first to get `teamId`, or take it from the board URL (/boards/team/<teamId>/...).',
     inputSchema: {
       type: 'object',
       properties: {
         teamId: {
           type: 'string',
           description:
-            'Team ID: use "0" for standalone Focalboard default team; for Mattermost Boards use the real team id from the board URL (/boards/team/<teamId>/...).',
+            'Team ID: use "0" for standalone Focalboard default team; for Mattermost Boards use `id` from list_teams or the board URL (/boards/team/<teamId>/...).',
           default: '0'
         }
       }
@@ -83,7 +98,7 @@ const tools: Tool[] = [
         teamId: {
           type: 'string',
           description:
-            'Team ID: "0" for standalone default team; Mattermost Boards needs the team id from the URL.',
+            'Team ID: "0" for standalone default team; Mattermost Boards: use `id` from list_teams or the board URL.',
           default: '0'
         },
         searchTerm: {
@@ -277,6 +292,27 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
       // ====================
       // Board Tools
       // ====================
+
+      case 'list_teams': {
+        const needle = ((args?.titleContains as string) || '').trim().toLowerCase();
+        let teams = await focalboard.listTeams();
+        if (needle) {
+          teams = teams.filter((t) => (t.title || '').toLowerCase().includes(needle));
+        }
+        const safe = teams.map((t) => ({
+          id: t.id,
+          title: t.title,
+          updateAt: t.updateAt,
+        }));
+        return {
+          content: [
+            {
+              type: 'text',
+              text: JSON.stringify(safe, null, 2),
+            },
+          ],
+        };
+      }
 
       case 'list_boards': {
         const teamId = (args?.teamId as string) || '0';

--- a/src/types.ts
+++ b/src/types.ts
@@ -111,13 +111,27 @@ export interface CardPatch {
 export interface BoardMember {
   boardId: string;
   userId: string;
-  roles: string;
-  minimumRole: string;
+  roles?: string;
+  minimumRole?: string;
   schemeAdmin: boolean;
   schemeEditor: boolean;
   schemeCommenter: boolean;
   schemeViewer: boolean;
-  synthetic: boolean;
+  synthetic?: boolean;
+}
+
+/** Board member + resolved Focalboard user profile (from POST /users). */
+export interface BoardUserRow {
+  userId: string;
+  username: string;
+  email: string;
+  firstname: string;
+  lastname: string;
+  nickname: string;
+  schemeAdmin: boolean;
+  schemeEditor: boolean;
+  schemeCommenter: boolean;
+  schemeViewer: boolean;
 }
 
 // Team represents a Focalboard team

--- a/src/types.ts
+++ b/src/types.ts
@@ -5,8 +5,15 @@
 
 export interface FocalboardConfig {
   host: string;
-  username: string;
-  password: string;
+  /** Standalone Focalboard: username for POST /api/v2/login. Ignored when accessToken is set. */
+  username?: string;
+  /** Standalone Focalboard: password for POST /api/v2/login. Ignored when accessToken is set. */
+  password?: string;
+  /**
+   * Mattermost Boards (plugin): Personal Access Token (or equivalent Bearer token).
+   * When set, login is skipped and this value is sent as Authorization Bearer on every request.
+   */
+  accessToken?: string;
 }
 
 export interface LoginRequest {


### PR DESCRIPTION
## Summary

Adds first-class support for **Mattermost Boards** (Personal Access Token auth, clearer env/docs), **`list_teams`** so clients can discover teams (optional name filter) instead of guessing team IDs, and **`list_board_users`** to list board members with usernames, emails, and role flags—plus clearer handling for assignee properties (Mattermost user ID vs username).

## Changes

### Mattermost Boards integration

- README: standalone Focalboard vs Mattermost Boards setup, env vars, and auth options.
- `FocalboardClient`: Mattermost PAT support for API authentication.
- Server bootstrap: config validation branches on token vs session-style credentials; clearer errors and tool copy around team IDs.
- Types updated as needed for the new auth path.

### Team listing

- `FocalboardClient.listTeams()` for teams the current user can access.
- New MCP tool: **`list_teams`** (optional name filter) and handler wiring in `index.ts`.

### Board members and assignees

- `FocalboardClient.listBoardUsers()` to retrieve board members (usernames, emails, admin/editor/commenter/viewer flags) with optional substring filter.
- New MCP tool: **`list_board_users`** and README documentation for resolving assignees.
- Card property handling improved so assignee-style fields can be resolved from Mattermost user IDs or usernames, with actionable errors when a username does not match a board member.